### PR TITLE
Bug fix: correct call to parse_nextcloud_scan_xml() when getting scan results

### DIFF
--- a/app/api/scan.py
+++ b/app/api/scan.py
@@ -482,11 +482,13 @@ class ScanFiles(Resource):
             # Instantiate dirs
             space_id = record_name
             fm_system_path = os.path.join(space_id, f"{space_id}-sys")
+            fm_space_path = os.path.join(space_id, f"{space_id}")
             root_dir_from_disk = Config.NEXTCLOUD_ROOT_DIR_PATH
+            user_dir = os.path.join(root_dir_from_disk, fm_space_path)
             full_sys_dir = os.path.join(root_dir_from_disk, fm_system_path)
 
             # Retrieve nextcloud metadata
-            nextcloud_md = helpers.parse_nextcloud_scan_xml(files.put_scandir(fm_system_path))
+            nextcloud_md = helpers.parse_nextcloud_scan_xml(user_dir, files.put_scandir(fm_system_path))
             for file_md in nextcloud_md:
                 if scan_id in file_md['path']:
                     file_path = helpers.get_correct_path(


### PR DESCRIPTION
In scan.py, the get() function (which returns a particluar results of a file scan of the space) featured a [call to the helpers.parse_nextcloud_scan_xml() function](https://github.com/usnistgov/oar-fm-application-layer/blob/30ae5726b866cbd9840b298a24d07f7c9f5c8687/app/api/scan.py#L489) that was missing one of its required arguments (the user-uploads directory), thus causing a `TypeError`.   This PR fixes this call by providing the needed argument.  